### PR TITLE
Promises resolving after `afterRender` in route hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,34 @@ containing form controls.
 
 ## Installation
 
-`ember install ember-fastboot-form-rehydration`
+```bash
+ember install ember-fastboot-form-rehydration
+```
+
+## Usage
+
+#### Import ember-fastboot-form-rehydration
+
+In your `app/router.js` file, import the mixin:
+
+```js
+import FormRehydration from 'ember-fastboot-form-rehydration';
+```
+
+And add `FormRehydration` as an extension to your Router object:
+
+```javascript
+const Router = Ember.Router.extend(FormRehydration, {});
+```
+
+#### Tests
+
+In your route and controller tests, add `'service:form-rehydration'` and `'service:form-rehydration'` as dependencies in the `needs: []` block:
+
+```js
+//{your-app}}/tests/unit/routes/{{your-route}}.js
+needs:['service:form-rehydration'],
+```
 
 ## The Problem
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,1 @@
+export { default } from './mixins/router';

--- a/addon/mixins/router.js
+++ b/addon/mixins/router.js
@@ -1,0 +1,24 @@
+import Mixin from '@ember/object/mixin';
+import { inject as service } from '@ember/service';
+import { schedule } from '@ember/runloop';
+import { get, set } from '@ember/object';
+
+export default Mixin.create({
+  formRehydration: service(),
+
+  didTransition() {
+    this._super(...arguments);
+
+    if (typeof FastBoot !== 'undefined') {
+      return;
+    }
+
+    let service = get(this, 'formRehydration');
+
+    if (!get(service, 'didRehydrate')) {
+      service.inspect();
+      schedule('afterRender', service, 'rehydrate');
+      set(service, 'didRehydrate', true);
+    }
+  }
+});

--- a/addon/services/form-rehydration.js
+++ b/addon/services/form-rehydration.js
@@ -13,6 +13,8 @@ export default Service.extend({
 
   selectors: ['input', 'textarea'],
 
+  didRehydrate: false,
+
   inspect() {
     let rootElement = getOwner(this).rootElement || '';
     let elements = document.querySelectorAll(this.get('selectors').map((sel) => `${rootElement} ${sel}`).join(','));

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,8 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
+import FormRehydration from 'ember-fastboot-form-rehydration';
 
-const Router = EmberRouter.extend({
+const Router = EmberRouter.extend(FormRehydration, {
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import RSVP from 'rsvp';
+
+export default Route.extend({
+  model() {
+    return new RSVP.Promise((resolve)=> {
+      setTimeout(()=> {
+        resolve();
+      }, 50);
+    });
+  }
+});

--- a/tests/unit/mixins/router-test.js
+++ b/tests/unit/mixins/router-test.js
@@ -1,0 +1,31 @@
+import EmberObject from '@ember/object';
+import RouterMixin from 'ember-fastboot-form-rehydration/mixins/router';
+import { module, test } from 'qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Mixin | router');
+
+test('inspect & rehydrate was called on the first didTransition', function(assert) {
+  assert.expect(2);
+
+  let RouterObject = EmberObject.extend(RouterMixin);
+  let subject = RouterObject.create({
+    formRehydration: {
+      inspect() {
+        assert.ok(true, `inspect was called`);
+      },
+
+      rehydrate() {
+        assert.ok(true, `rehydrate was called`);
+      }
+    }
+  });
+
+  run(()=> {
+    subject.didTransition();
+  });
+
+  run(()=> {
+    subject.didTransition(); // Testing inspect & rehydrate was not called on subsequent transitions
+  })
+});


### PR DESCRIPTION
Currently the biggest obstacle I'm facing is that `afterRender` scheduled in the instance initializer runs before the route hooks resolve.

One possible solution would be to run `inspect` + `rehydrate` once again from the route's `didTransition` hook. This way no matter how long it took for the promises to resolve, the data entered would've been kept.

This PR only demonstrates the issue so far by returning a promise from the application route's `model` hook and resolving it after `afterRender` already ran. (And, therefore, making tests fail.)