### PR TITLE
Restore selection for the focused input

### DIFF
--- a/addon/services/form-rehydration.js
+++ b/addon/services/form-rehydration.js
@@ -9,6 +9,11 @@ function triggerBasicEvent(el, type) {
   el.dispatchEvent(event);
 }
 
+// https://html.spec.whatwg.org/multipage/input.html#concept-input-apply
+function supportsSelection(input) {
+  return /^(text|search|password|tel|url)$/.test(input.type);
+}
+
 export default Service.extend({
 
   selectors: ['input', 'textarea'],
@@ -24,7 +29,16 @@ export default Service.extend({
       .reduce((result, item) => assign(result, item), {})
     ;
     this.values = props;
-    this.activeElement = document.activeElement && document.activeElement.name;
+
+    if (document.activeElement) {
+      this.activeElementName = document.activeElement.name;
+
+      if (supportsSelection(document.activeElement)) {
+        this.selectionStart = document.activeElement.selectionStart;
+        this.selectionEnd = document.activeElement.selectionEnd;
+        this.selectionDirection = document.activeElement.selectionDirection;
+      }
+    }
   },
 
   rehydrate() {
@@ -39,8 +53,13 @@ export default Service.extend({
       }
     }
 
-    if (this.activeElement) {
-      document.querySelector(`[name="${this.activeElement}"]`).focus();
+    if (this.activeElementName) {
+      let activeElement = document.querySelector(`[name="${this.activeElementName}"]`);
+      activeElement.focus();
+
+      if (supportsSelection(activeElement)) {
+        activeElement.setSelectionRange(this.selectionStart, this.selectionEnd, this.selectionDirection);
+      }
     }
   }
 });

--- a/tests/acceptance/form-rehydration-test.js
+++ b/tests/acceptance/form-rehydration-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { visit, find } from 'ember-native-dom-helpers';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -41,6 +41,66 @@ test('it restores focus', async function(assert) {
   await visit('/');
 
   assert.equal(find('input[name="title"]'), document.activeElement);
+
+  await destroyApp(this.application);
+});
+
+test('it restores selection for the active element', async function(assert) {
+  document.querySelector(rootSelector).innerHTML = staticFormMarkup;
+  let input = document.querySelector(`${rootSelector} input[name="title"]`);
+  input.value = 'foo';
+  input.focus();
+
+  input.setSelectionRange(0, 1); // Selecting "f" from "foo"
+
+  this.application = startApp();
+
+  await visit('/');
+
+  let resultInput = find('input[name="title"]');
+  assert.equal(resultInput.selectionStart, 0, 'selectionStart is correct');
+  assert.equal(resultInput.selectionEnd, 1, 'selectionEnd is correct');
+
+  await destroyApp(this.application);
+});
+
+// https://html.spec.whatwg.org/multipage/input.html#concept-input-apply
+test(`it doesn't throw for an input with no selection support`, async function(assert) {
+  assert.expect(0);
+
+  document.querySelector(rootSelector).innerHTML = `<input name="title" type="number">`;
+  document.querySelector(`${rootSelector} input[name="title"]`).focus();
+
+  this.application = startApp();
+
+  await visit('/');
+  await destroyApp(this.application);
+});
+
+
+// All input selections could be restored in theory, but it adds very little value in practice...
+skip(`it restores selection for all input elements`, async function(assert) {
+  document.querySelector(rootSelector).innerHTML = staticFormMarkup;
+  let input = document.querySelector(`${rootSelector} input[name="title"]`);
+  let textarea = document.querySelector(`${rootSelector} textarea[name="text"]`);
+
+  input.value = 'foo';
+  input.setSelectionRange(0, 1); // Selecting "f" from "foo"
+
+  textarea.value = 'bar';
+  textarea.setSelectionRange(1, 2); // Selecting "a" from "bar"
+
+  this.application = startApp();
+
+  await visit('/');
+
+  let resultInput = find('input[name="title"]');
+  assert.equal(resultInput.selectionStart, 0, 'selectionStart is correct for the input element');
+  assert.equal(resultInput.selectionEnd, 1, 'selectionEnd is correct for the input element');
+
+  let resultTextarea = find('textarea[name="text"]');
+  assert.equal(resultTextarea.selectionStart, 1, 'selectionStart is correct for the textare');
+  assert.equal(resultTextarea.selectionEnd, 2, 'selectionEnd is correct for the textare');
 
   await destroyApp(this.application);
 });


### PR DESCRIPTION
@simonihmig Could you please review? :)

I've added a skipped test which would be rather straightforward to implement, but I thought rewriting a good portion of the service for such an edge case is an overkill.