### PR TITLE
Don't try to restore focus on non-existent inputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/addon/services/form-rehydration.js
+++ b/addon/services/form-rehydration.js
@@ -55,10 +55,12 @@ export default Service.extend({
 
     if (this.activeElementName) {
       let activeElement = document.querySelector(`[name="${this.activeElementName}"]`);
-      activeElement.focus();
+      if (activeElement) {
+        activeElement.focus();
 
-      if (supportsSelection(activeElement)) {
-        activeElement.setSelectionRange(this.selectionStart, this.selectionEnd, this.selectionDirection);
+        if (supportsSelection(activeElement)) {
+          activeElement.setSelectionRange(this.selectionStart, this.selectionEnd, this.selectionDirection);
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "6.* || >= 7.*"
+    "node": ">= 10.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/acceptance/form-rehydration-test.js
+++ b/tests/acceptance/form-rehydration-test.js
@@ -101,6 +101,19 @@ test(`it doesn't throw for an input with no selection support`, async function(a
   await destroyApp(this.application);
 });
 
+test(`it doesn't throw when an input that was focused in the server-rendered output no longer exists`, async function(assert) {
+  assert.expect(0);
+
+  document.querySelector(rootSelector).innerHTML = staticFormMarkup;
+  document.querySelector(`${rootSelector} input[name="title"]`).focus();
+
+  this.application = startApp();
+  this.application.__container__.lookup('controller:application').set('shouldRenderForm', false);
+
+  await visit('/');
+  await destroyApp(this.application);
+});
+
 
 // All input selections could be restored in theory, but it adds very little value in practice...
 skip(`it restores selection for all input elements`, async function(assert) {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,6 +1,8 @@
 import Controller from '@ember/controller';
 
 export default Controller.extend({
+  shouldRenderForm: true,
+
   actions: {
     change(e) {
       e.target.classList.add('event-change');

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,6 @@
-<form>
-  <input name="title" onchange={{action "change"}} oninput={{action "input"}}>
-  <textarea name="text" onchange={{action "change"}} oninput={{action "input"}}></textarea>
-</form>
+{{#if shouldRenderForm}}
+  <form>
+    <input name="title" onchange={{action "change"}} oninput={{action "input"}}>
+    <textarea name="text" onchange={{action "change"}} oninput={{action "input"}}></textarea>
+  </form>
+{{/if}}


### PR DESCRIPTION
Essentially the same check that happens [here](https://github.com/kaliber5/ember-fastboot-form-rehydration/blob/master/addon/services/form-rehydration.js#L49), for the focused input.